### PR TITLE
Update TestPrometheusRecordSink.java, Flaky Fixed

### DIFF
--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -53,7 +53,7 @@ import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -80,12 +80,12 @@ public class TestPrometheusRecordSink {
         );
         RecordSchema recordSchema = new SimpleRecordSchema(recordFields);
 
-        Map<String, Object> row1 = new HashMap<>();
+        Map<String, Object> row1 = new LinkedHashMap<>();
         row1.put("field1", 15);
         row1.put("field2", BigDecimal.valueOf(12.34567D));
         row1.put("field3", "Hello");
 
-        Map<String, Object> row2 = new HashMap<>();
+        Map<String, Object> row2 = new LinkedHashMap<>();
         row2.put("field1", 6);
         row2.put("field2", BigDecimal.valueOf(0.1234567890123456789D));
         row2.put("field3", "World!");
@@ -95,7 +95,7 @@ public class TestPrometheusRecordSink {
                 new MapRecord(recordSchema, row2)
         ));
 
-        Map<String, String> attributes = new HashMap<>();
+        Map<String, String> attributes = new LinkedHashMap<>();
         attributes.put("a", "Hello");
         WriteResult writeResult = sink.sendData(recordSet, attributes, true);
         assertNotNull(writeResult);
@@ -104,8 +104,10 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
+        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n")||
+            content.contains("field1{field3=\"World!\",} 6.0\nfield1{field3=\"Hello\",} 15.0"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n")||
+            content.contains("field2{field3=\"World!\",} 0.12345678901234568\nfield2{field3=\"Hello\",} 12.34567\n"));
 
         try {
             sink.onStopped();


### PR DESCRIPTION
# Summary
The test TestPrometheusRecordSink.testSendData() is done by comparing a hardcoded String while the output of the test does not give a deterministic one. Or in other words, this is a flaky test. 
Flaky Fixed by:
1. Changing Hashmap into LinkedHashmap.
2. Adding additional cases for assertTrue. (eg. the original one only contains the case AB but no BA)
